### PR TITLE
Update fstab file to support F2FS userdata partition

### DIFF
--- a/out/ramdisk/fstab.mofd_v1
+++ b/out/ramdisk/fstab.mofd_v1
@@ -2,6 +2,7 @@
 /dev/block/by-name/cache  	/cache  	ext4	nosuid,nodev,noatime,barrier=1,data=ordered                        	wait,check                                     
 /dev/block/by-name/config 	/config 	ext4	nosuid,nodev,noatime,barrier=1,data=ordered                        	wait                                           
 /dev/block/by-name/data   	/data   	ext4	nosuid,nodev,noatime,discard,barrier=1,data=ordered,noauto_da_alloc	wait,check,encryptable=/factory/userdata_footer
+/dev/block/by-name/data     /data     f2fs  noatime,nosuid,nodev,discard,nodiratime,inline_xattr,errors=recover wait,nonremovable,encryptable=/factory/userdata_footer
 /dev/block/by-name/factory	/factory	ext4	nosuid,nodev,noatime,barrier=1,data=ordered                        	wait                                           
 */block/sda*              	auto    	vfat	None	wait,voldmanaged=USBdisk1:auto                                
 */block/sdb*              	auto    	vfat	None	wait,voldmanaged=USBdisk2:auto                                


### PR DESCRIPTION
Edited fstab file to try to enable mounting /data partition formatted in both F2FS and ext4. according with it: http://forum.xda-developers.com/showpost.php?p=57921263&postcount=453 with the changes needed by ZF2.
