### PR TITLE
Update -march to silvermont and exclusive Intel C Compiler option to Silvermont

### DIFF
--- a/arch/x86/Makefile_32.cpu
+++ b/arch/x86/Makefile_32.cpu
@@ -35,10 +35,10 @@ cflags-$(CONFIG_MCORE2)		+= -march=i686 $(call tune,core2)
 cflags-$(CONFIG_MATOM)		+= $(call cc-option,-march=atom,$(call cc-option,-march=core2,-march=i686)) \
 	$(call cc-option,-mtune=atom,$(call cc-option,-mtune=generic))
 # Intel Silvermont architeture specific mtune
-cflags-$(CONFIG_MSLM)		+= -march=i686 $(call tune,silvermont)
+cflags-$(CONFIG_MSLM)		+= -march=silvermont $(call tune,silvermont)
 #cflags-$(CONFIG_MSLM)		+= $(call cc-option,-march=slm,$(call cc-option,-march=core2,-march=i686)) \
 	$(call cc-option,-mtune=slm,$(call cc-option,-mtune=generic))
-#cflags-$(CONFIG_MSLM)		+= $(call cc-option,-xSSSE3_ATOM)
+#cflags-$(CONFIG_MSLM)		+= $(call cc-option,-xatom_SSE4.2)
 
 # AMD Elan support
 cflags-$(CONFIG_MELAN)		+= -march=i486


### PR DESCRIPTION
Update -march=silvermont (not i686). Update the commented line with Intel CC option to xatom_SSE4.2 according Intel official material: https://software.intel.com/sites/default/files/managed/bb/2c/02_Intel_Silvermont_Microarchitecture.pdf (page 32)
