### PR TITLE
Aditional optimizations in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,12 +253,14 @@ CONFIG_SHELL := $(shell if [ -x "$$BASH" ]; then echo $$BASH; \
 
 HOSTCC       = $(CCACHE) gcc
 HOSTCXX      = $(CCACHE) g++
-HOSTCFLAGS   = -Wall -Wmissing-prototypes -Wstrict-prototypes -O3 -fno-tree-vectorize -fomit-frame-pointer
+HOSTCFLAGS   = -Wall -Wmissing-prototypes -Wstrict-prototypes -O3 -fomit-frame-pointer
+# HOSTCFLAGS   = -Wall -Wmissing-prototypes -Wstrict-prototypes -O3 -fno-tree-vectorize -fomit-frame-pointer
 HOSTCXXFLAGS = -O3
 HOSTCC       = $(CCACHE) gcc
 HOSTCXX      = $(CCACHE) g++
 HOSTCFLAGS   = -Wall -Wmissing-prototypes -Wstrict-prototypes -Ofast -fomit-frame-pointer -fgcse-las -std=gnu89
-HOSTCXXFLAGS = -Ofast -fgcse-las
+# HOSTCXXFLAGS = -Ofast -march=silvermont -mtune=silvermont -mssse4.2 -mpopcnt -fgcse-las
+HOSTCXXFLAGS = -Ofast -march=silvermont -mtune=silvermont -mssse4.2 -mpopcnt -ftree-vectorize -fgcse-las
 ifeq ($(ENABLE_GRAPHITE),true)
 HOSTCXXFLAGS += -fgraphite -floop-flatten -floop-parallelize-all -ftree-loop-linear -floop-interchange -floop-strip-mine -floop-block
 HOSTCFLAGS += -fgraphite -floop-flatten -floop-parallelize-all -ftree-loop-linear -floop-interchange -floop-strip-mine -floop-block


### PR DESCRIPTION
add specific silvermont optimizations and active ftree-vectorize to gain the advantages of SIMD SSE4.2 vectorization (test ftree-vectorize). If it dont work, remove new lines and activate the commited lines.
